### PR TITLE
build: update Node to LTS 24.11 and Yarn to 4.10.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM cimg/node:22.15-browsers
+FROM cimg/node:24.11-browsers
 
 RUN sudo apt-get -o Acquire::AllowInsecureRepositories=true update && \
     sudo apt-get --allow-unauthenticated install -y zstd xvfb
 # Install corepack and yarn
-RUN sudo corepack enable && sudo corepack prepare yarn@4.9.1 --activate
+RUN sudo corepack enable && sudo corepack prepare yarn@4.10.3 --activate

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This image is built for running MetaMask Extension end-to-end (E2E) tests.  
 It includes:
 
-- Node 22.15 (with browsers)
-- Yarn 4.9.1 (via Corepack)
+- Node 24.11 (with browsers)
+- Yarn 4.10.3 (via Corepack)
 - zstd compression tool
 - Xvfb for headless GUI environments
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update Docker image to Node 24.11 (browsers) and Yarn 4.10.3; reflect versions in README.
> 
> - **Dockerfile**:
>   - Update base image to `cimg/node:24.11-browsers`.
>   - Bump Yarn via Corepack to `4.10.3`.
> - **Docs**:
>   - Update README to list Node `24.11` and Yarn `4.10.3`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41ed7de3dc9ad48891913b41c354d3920c27a682. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->